### PR TITLE
Fixed Bug in LoreTreeWidget not allowing un-nesting

### DIFF
--- a/src/python/ui/widgets/lore_tree_widget.py
+++ b/src/python/ui/widgets/lore_tree_widget.py
@@ -19,7 +19,7 @@ class LoreTreeWidget(QTreeWidget):
     lore_parent_id_updated = pyqtSignal(int, object)
     """:py:class:`~PyQt6.QtCore.pyqtSignal` (int, object): Signal to connect back to the LoreOutlineManager"""
 
-    lore_hierarchy_updated = pyqtSignal(int, int)
+    lore_hierarchy_updated = pyqtSignal(int, object)
     """:py:class:`~PyQt6.QtCore.pyqtSignal` (int, int, int): Signal to connect back to the LoreOutlineManager"""
 
     def __init__(self, id_role: int, parent=None):
@@ -76,8 +76,13 @@ class LoreTreeWidget(QTreeWidget):
                 actual_parent = target_item.parent()
 
         # 4. Extract the ID from the determined parent
-        new_parent_id = actual_parent.data(0, self.id_role) if actual_parent else None
-
+        if actual_parent:
+            new_parent_id = actual_parent.data(0, self.id_role)
+            if new_parent_id == 0 or new_parent_id is None:
+                new_parent_id = None
+        else:
+            new_parent_id = None
+        
         # 5. Update siblings for sort order
         iteration_root = actual_parent or self.invisibleRootItem()
         for i in range(iteration_root.childCount()):


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [X] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

A bug was found in when trying to unnset items
in LoretreeWidget.DropEvent. The bug was the pyQtSignal
lore_hierarchy_updated had types (int, int) defined but
was trying to emit (int, None) if there was no
parent. This has been fixed to lore_hierarchy_updated 
now emits types (int, obj). 

Another check was also added in LoretreeWidget.DropEvent
that ensures the Parent id is either and int value or None.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `nf_core_wrapper.py` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.