### PR TITLE
Move Signals for Editors and OutlineManagers to ViewManager

### DIFF
--- a/src/python/ui/view_manager.py
+++ b/src/python/ui/view_manager.py
@@ -2,6 +2,7 @@
 
 from PyQt6.QtWidgets import QStackedWidget
 from PyQt6.QtCore import QObject, pyqtSignal
+
 from ..utils.constants import ViewType
 from ..utils.logger import get_logger
 
@@ -9,6 +10,7 @@ from ..utils.logger import get_logger
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..services.app_coordinator import AppCoordinator
+    from .menu.main_menu_bar import MainMenuBar
     from .views.chapter_outline_manager import ChapterOutlineManager
     from .views.chapter_editor import ChapterEditor
     from .views.lore_outline_manager import LoreOutlineManager
@@ -34,7 +36,8 @@ class ViewManager(QObject):
     carrying the new ViewType.
     """
 
-    def __init__(self, outline_stack: QStackedWidget, editor_stack: QStackedWidget, coordinator: 'AppCoordinator') -> None:
+    def __init__(self, outline_stack: QStackedWidget, editor_stack: QStackedWidget, 
+                 coordinator: 'AppCoordinator', main_menu_bar: 'MainMenuBar') -> None:
         """
         Creates the ViewManager Object.
         
@@ -51,6 +54,7 @@ class ViewManager(QObject):
         self.outline_stack = outline_stack
         self.editor_stack = editor_stack
         self.coordinator = coordinator
+        self.main_menu_bar = main_menu_bar
 
         # Map ViewType to Stack Index
         self._view_indices = {
@@ -60,6 +64,74 @@ class ViewManager(QObject):
             ViewType.NOTE_EDITOR: 3,
             ViewType.RELATIONSHIP_GRAPH: 4
         }
+
+        self._connect_view_signals()
+
+    def _connect_view_signals(self) -> None:
+        """
+        Connects navigation and view-state signals internally.
+        
+        :rtype: None
+        """
+        self.main_menu_bar.view_switch_requested.connect(self.switch_to_view)
+        self.view_changed.connect(self.main_menu_bar.update_view_checkmarks)
+
+        chapter_editor: ChapterEditor = self.editor_stack.widget(0) # ChapterEditor
+        lore_editor: LoreEditor = self.editor_stack.widget(1)    # LoreEditor
+        char_editor: CharacterEditor = self.editor_stack.widget(2)    # ChapterEditor
+        note_editor: NoteEditor = self.editor_stack.widget(3) # NoteEditor
+        rel_editor: RelationshipEditor = self.editor_stack.widget(4)
+
+        chapter_outline: ChapterOutlineManager = self.outline_stack.widget(0) # ChapterOutlineManager
+        lore_outline: LoreOutlineManager = self.outline_stack.widget(1)    # LoreOutlineManager
+        char_outline: CharacterOutlineManager = self.outline_stack.widget(2)    # CharacterOutlineManager
+        note_outline: NoteOutlineManager = self.outline_stack.widget(3) # NoteOutlineManager
+        rel_outline: RelationshipOutlineManager = self.outline_stack.widget(4)
+
+        # New Item Created Connect to Switch View
+        chapter_outline.new_item_created.connect(lambda: self.switch_to_view(ViewType.CHAPTER_EDITOR))
+        lore_outline.new_item_created.connect(lambda: self.switch_to_view(ViewType.LORE_EDITOR))
+        char_outline.new_item_created.connect(lambda: self.switch_to_view(ViewType.CHARACTER_EDITOR))
+        note_outline.new_item_created.connect(lambda: self.switch_to_view(ViewType.NOTE_EDITOR))
+
+        # Pre Item Change Connect to AppCoordinator.check_save_before_change
+        chapter_outline.pre_item_change.connect(self.coordinator.check_and_save_dirty)
+        lore_outline.pre_item_change.connect(self.coordinator.check_and_save_dirty)
+        char_outline.pre_item_change.connect(self.coordinator.check_and_save_dirty)
+        note_outline.pre_item_change.connect(self.coordinator.check_and_save_dirty)
+
+        # Outline Item Select -> AppCoordinator.load_item(item_id, ViewType)
+        chapter_outline.item_selected.connect(
+            lambda item_id: self.coordinator.load_item(item_id, ViewType.CHAPTER_EDITOR)
+        )
+        lore_outline.item_selected.connect(
+            lambda item_id: self.coordinator.load_item(item_id, ViewType.LORE_EDITOR)
+        )
+        char_outline.item_selected.connect(
+            lambda item_id: self.coordinator.load_item(item_id, ViewType.CHARACTER_EDITOR)
+        )
+        note_outline.item_selected.connect(
+            lambda item_id: self.coordinator.load_item(item_id, ViewType.NOTE_EDITOR)
+        )
+
+        # MainMenuBar New Item Connect to outline.prompt_and_add_*item*
+        self.main_menu_bar.new_chapter_requested.connect(chapter_outline.prompt_and_add_chapter)
+        self.main_menu_bar.new_lore_requested.connect(lore_outline.prompt_and_add_lore)
+        self.main_menu_bar.new_character_requested.connect(char_outline.prompt_and_add_character)
+
+        # Item Selected to Coordinator.load_item(item_id, ViewType.Editor)
+        self.coordinator.chapter_loaded.connect(chapter_editor.load_entity)
+        self.coordinator.lore_loaded.connect(lore_editor.load_entity)
+        self.coordinator.char_loaded.connect(char_editor.load_entity)
+        self.coordinator.note_loaded.connect(note_editor.load_entity)
+
+        # Load & Reload Graph Data
+        self.coordinator.graph_data_loaded.connect(rel_editor.load_graph)
+        rel_outline.relationship_types_updated.connect(self.coordinator.reload_relationship_graph_data)
+
+        # Lore Categores
+        self.coordinator.lore_categories_changed.connect(lore_editor.set_available_categories)
+
 
     def switch_to_view(self, view: ViewType) -> None:
         """


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [X] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

The OutlineManager and Editor signal connections to the 
MainMenuBar,coordinator have been moved to ViewManager.
This was done to lighten the load of what MainWindow is and
does.

## 🔗 Related Tasks

- Fixes # N/A

### **Frontend (Python)**

- [X] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `nf_core_wrapper.py` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.