### PR TITLE
RelationshipEditor Now Uses the Event Bus over Signals

### DIFF
--- a/src/python/main_window.py
+++ b/src/python/main_window.py
@@ -307,32 +307,9 @@ class MainWindow(QMainWindow):
         # Connect Main Menu Project Stats Dialog Openm
         self.main_menu_bar.project_stats_requested.connect(self._open_project_stats_dialog)
 
-        # --- Relationship Graph Wiring (The "Glue") ---
-
-        # Requests from ViewManager to Coordinator
-        self.view_manager.graph_load_requested.connect(self.coordinator.load_relationship_graph_data)
-        # self.view_manager.rel_types_requested.connect(self.coordinator.load_relationship_types_for_editor)
-        self.view_manager.node_attributes_save_requested.connect(self.coordinator.save_node_position)
-        self.view_manager.relationship_create_requested.connect(self.coordinator.save_new_relationship)
-        self.view_manager.relationship_delete_requested.connect(self.coordinator.handle_relationship_deletion)
-
-        # Data back from Coordinator to ViewManager
-        self.coordinator.graph_data_loaded.connect(self.view_manager.graph_data_received)
-        self.coordinator.relationship_types_available.connect(self.view_manager.rel_types_received)
-
         logger.info("Component signal connections complete.")
 
     # --- Coordinator/ViewManager ---
-
-    # def _distribute_data_to_editor(self, data) -> None:
-    #     """
-    #     Distributes data to Edtior
-        
-    #     :rtype: None
-    #     """
-    #     editor = self.view_manager.get_current_editor()
-    #     if editor:
-    #         editor.load_entity(data)
 
     def save_helper(self):
         """
@@ -351,7 +328,7 @@ class MainWindow(QMainWindow):
         data = {'entity_type': map.get(view), 'parent': self, 'ID': self.coordinator.current_item_id}
         data |= editor.get_save_data()
 
-        return self.coordinator.check_and_save_dirty_bus(data=data)
+        return self.coordinator.check_and_save_dirty(data=data)
 
 
     def _on_save_triggered(self) -> None:
@@ -370,15 +347,6 @@ class MainWindow(QMainWindow):
         data |= editor.get_save_data()
 
         return self.coordinator.save_current_item(data=data)
-
-    # @receiver(Events.PRE_ITEM_CHANGE)
-    # def _on_item_change(self, data: dict) -> None:
-    #     """
-    #     Called when PRE_ITEM_CHANGE is emittted to change and save.
-    #     """
-    #     editor = self.view_manager.get_current_editor()
-    #     view = self.view_manager.get_current_view()
-    #     self.coordinator.check_and_save_dirty(view=view, editor=editor)
 
     # --- For Creating/Opening other Projects ---
 

--- a/src/python/repository/relationship_repository.py
+++ b/src/python/repository/relationship_repository.py
@@ -72,6 +72,26 @@ class RelationshipRepository:
         except DatabaseError as e:
             logger.error("Failed to retrieve all character relationships for graph.", exc_info=True)
             raise e
+        
+    def get_relationship_details(self, rel_id: int) -> dict:
+        """
+        Gets the Details of a relationship from the database based on ID.
+        
+        :param rel_id: The ID of the relationship.
+        :type rel_id: int
+
+        :returns: Dict of all the Relationship Data.
+        :rtype dict:
+        """
+        query = "SELECT * FROM Character_Relationships WHERE ID = ?"
+        try:
+            rel_data = self.db._execute_query(query, (rel_id,), fetch_one=True)
+            if rel_data:
+                logger.info(f"Got details for Relationship: ID={rel_id}.")
+            return rel_data
+        except DatabaseError as e:
+            logger.error(f"Failed to get details for relationship with ID {rel_id}.", exc_info=True)
+            raise e
     
     def create_relationship(self, char_a_id: int, char_b_id: int, type_id: int, lore_id: int | None = None,
                             description: str = "", intensity: int = 5, start_chapter_id: int | None = None, 
@@ -135,9 +155,27 @@ class RelationshipRepository:
             raise e
 
     def update_relationship_details(self, relationship_id: int, type_id: int, description: str, 
-                                    intensity: int, lore_id: int | None, start_chapter_id: int | None, 
-                                    end_chapter_id: int | None) -> bool:
-        """Updates the non-ID fields of an existing relationship."""
+                                    intensity: int, lore_id: int | None = None, start_chapter_id: int | None = None, 
+                                    end_chapter_id: int | None = None) -> bool:
+        """
+        Updates the details of a relationships.
+        
+        :param relationship_id: The ID of the relationship.
+        :type relationship_id: int
+        :param type_id: The ID of the relationship type.
+        :type type_id: int
+        :param description: The description of the relationship.
+        :type description: str
+        :param intensity: The intensity of the relationship.
+        :type intensity: int
+                :param lore_id: The ID of the Lore Type of the Relationship.
+        :type lore_id: int
+        :param start_chapter_id: The chapter ID that the relationship begins in. Default is None.
+        :type start_chapter_id: int or None
+        :param end_chapter_id: The chapter ID that the relationships ends in. Default is None.
+        :type end_chapter_id: int or None
+        """
+
         query = """
         UPDATE Character_Relationships SET
             Type_ID = ?,
@@ -153,6 +191,7 @@ class RelationshipRepository:
             success = self.db._execute_commit(query, params)
             if success:
                 logger.info(f"Character relationship details updated: ID={relationship_id}.")
+            print(success)
             return success
 
         except DatabaseError as e:

--- a/src/python/ui/dialogs/relationship_dialog.py
+++ b/src/python/ui/dialogs/relationship_dialog.py
@@ -11,7 +11,8 @@ class RelationshipCreationDialog(QDialog):
     
     Presents fields for Relationship Type, Description, and Intensity.
     """
-    def __init__(self, relationship_types: list[dict], char_a_name: str, char_b_name: str, parent=None) -> None:
+    def __init__(self, relationship_types: list[dict], char_a_name: str, char_b_name: str, 
+                 description: str = "", intensity: int = 5, parent=None) -> None:
         """
         Initializes :py:class:`.RelationshipCreationDialog`.
         
@@ -34,7 +35,7 @@ class RelationshipCreationDialog(QDialog):
         layout = QFormLayout(self)
         
         # Display the characters being connected
-        layout.addRow(QLabel(f"Connecting: **{char_a_name}** to **{char_b_name}**"))
+        layout.addRow(QLabel(f"Connecting: {char_a_name} to {char_b_name}"))
         
         # Relationship Type selection
         self.type_combo = QComboBox()
@@ -45,12 +46,13 @@ class RelationshipCreationDialog(QDialog):
         
         # Description
         self.description_input = QLineEdit()
+        self.description_input.setText(description)
         layout.addRow("Description:", self.description_input)
         
         # Intensity (e.g., a simple 1-10 scale)
         self.intensity_input = QSpinBox()
         self.intensity_input.setRange(1, 10) # Intensity is on Simple 1-10 Scale but multipled by scalar later
-        self.intensity_input.setValue(5)
+        self.intensity_input.setValue(intensity)
         layout.addRow("Intensity (0-10):", self.intensity_input)
         
         # Buttons

--- a/src/python/ui/dialogs/relationship_type_editor_dialog.py
+++ b/src/python/ui/dialogs/relationship_type_editor_dialog.py
@@ -1,0 +1,64 @@
+# src\python\ui\dialogs\relationship_type_editor_dialog.py
+
+from PySide6.QtWidgets import (
+    QPushButton, QColorDialog, QLineEdit, QDialog, QFormLayout, QComboBox, QDialogButtonBox
+)
+from PySide6.QtGui import QColor
+
+class RelationshipTypeEditorDialog(QDialog):
+    def __init__(self, parent=None, details=None):
+        super().__init__(parent)
+        self.setWindowTitle("Edit Relationship Type")
+        self.setMinimumWidth(350)
+        
+        layout = QFormLayout(self)
+
+        # Inputs
+        self.name_edit = QLineEdit(details.get('Type_Name', ''))
+        self.short_label_edit = QLineEdit(details.get('Short_Label', ''))
+        
+        # Color - Storing the hex string
+        self.color_button = QPushButton(details.get('Default_Color', '#000000'))
+        self.color_button.setStyleSheet(f"background-color: {self.color_button.text()}; color: white;")
+        self.color_button.clicked.connect(self._pick_color)
+        self.current_color = details.get('Default_Color', '#000000')
+
+        # Line Style
+        self.style_combo = QComboBox()
+        self.style_combo.addItems(['Solid', 'Dash', 'Dot', 'DashDot'])
+        self.style_combo.setCurrentText(details.get('Line_Style', 'Solid'))
+
+        # Directionality
+        self.direction_combo = QComboBox()
+        self.direction_combo.addItem("Undirected (A <-> B)", 0)
+        self.direction_combo.addItem("Directed (A -> B)", 1)
+        self.direction_combo.setCurrentIndex(1 if details.get('Is_Directed', 0) else 0)
+
+        # Add to layout
+        layout.addRow("Type Name:", self.name_edit)
+        layout.addRow("Short Label:", self.short_label_edit)
+        layout.addRow("Default Color:", self.color_button)
+        layout.addRow("Line Style:", self.style_combo)
+        layout.addRow("Directionality:", self.direction_combo)
+
+        # Buttons
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addRow(self.buttons)
+
+    def _pick_color(self):
+        color = QColorDialog.getColor(QColor(self.current_color), self)
+        if color.isValid():
+            self.current_color = color.name()
+            self.color_button.setText(self.current_color)
+            self.color_button.setStyleSheet(f"background-color: {self.current_color};")
+
+    def get_values(self):
+        return {
+            "name": self.name_edit.text().strip(),
+            "short_label": self.short_label_edit.text().strip(),
+            "color": self.current_color,
+            "style": self.style_combo.currentText(),
+            "is_directed": self.direction_combo.currentData()
+        }

--- a/src/python/ui/ui_factory.py
+++ b/src/python/ui/ui_factory.py
@@ -50,7 +50,7 @@ class UIFactory:
             'note_outline': NoteOutlineManager(project_title=project_title),
             'note_editor': NoteEditor(settings),
 
-            'relationship_outline': RelationshipOutlineManager(relationship_repository=coordinator.relationship_repo),
+            'relationship_outline': RelationshipOutlineManager(),
             'relationship_editor': RelationshipEditor()
         }
 

--- a/src/python/ui/view_manager.py
+++ b/src/python/ui/view_manager.py
@@ -107,12 +107,12 @@ class ViewManager(QObject):
     graph data is received containng the Nodes and Edges.
     """
 
-    rel_types_received = Signal(list)
-    """
-    :py:class:`~PySide6.QtCore.Signal` (list): Emitted wehn
-    the relationship types are recieved containing a list
-    of the names of the Relationship Types.
-    """
+    # rel_types_received = Signal(list)
+    # """
+    # :py:class:`~PySide6.QtCore.Signal` (list): Emitted wehn
+    # the relationship types are recieved containing a list
+    # of the names of the Relationship Types.
+    # """
 
     def __init__(self, outline_stack: QStackedWidget, editor_stack: QStackedWidget) -> None:
         """
@@ -166,18 +166,6 @@ class ViewManager(QObject):
         self.new_chapter_requested.connect(chapter_outline.prompt_and_add_chapter)
         self.new_lore_requested.connect(lore_outline.prompt_and_add_lore)
         self.new_character_requested.connect(char_outline.prompt_and_add_character)
-
-        # --- Relationship Graph Relays (No Coordinator calls) ---
-        
-        # Data Flow: Editor -> ViewManager (Relay)
-        rel_editor.save_node_attributes.connect(self.node_attributes_save_requested.emit)
-        rel_editor.request_load_rel_types.connect(self.rel_types_requested.emit)
-        rel_editor.relationship_created.connect(self.relationship_create_requested.emit)
-        rel_editor.relationship_deleted.connect(self.relationship_delete_requested.emit)
-        
-        # Data Flow: ViewManager (Input) -> Editor
-        self.graph_data_received.connect(rel_editor.load_graph)
-        self.rel_types_received.connect(rel_editor.set_available_relationship_types)
 
     def get_current_editor(self) -> 'BaseEditor':
         """
@@ -235,7 +223,9 @@ class ViewManager(QObject):
 
         if view == ViewType.RELATIONSHIP_GRAPH:
             # Load Graph Data
-            self.graph_load_requested.emit()
+            # self.graph_load_requested.emit()
+            bus.publish(Events.GRAPH_LOAD_REQUESTED)
+
             entity_type = EntityType.RELATIONSHIP
 
         elif view == ViewType.CHAPTER_EDITOR:

--- a/src/python/ui/widgets/graph_items.py
+++ b/src/python/ui/widgets/graph_items.py
@@ -8,6 +8,9 @@ from PySide6.QtGui import QColor, QPen, QBrush, QFont
 import math
 from typing import Any
 
+from ...utils.events import Events
+from ...utils.event_bus import bus
+
 class CharacterNodeSignals(QObject):
     """
     Signal Emitter for :py:class:`.CharacterNode`.
@@ -361,6 +364,6 @@ class RelationshipEdge(QGraphicsLineItem):
         action = menu.exec(event.screenPos())
         
         if action == edit_action:
-            editor.edit_relationship(self)
+            bus.publish(Events.REL_DETAILS_REQUESTED, data={'source': self.source_node, 'target': self.target_node, 'ID': self.edge_data.get('id')})
         elif action == delete_action:
-            editor.delete_relationship(self)
+            bus.publish(Events.REL_DELETE_REQUESTED, data={'source': self.source_node, 'target': self.target_node, 'ID': self.edge_data.get('id')})

--- a/src/python/utils/events.py
+++ b/src/python/utils/events.py
@@ -59,10 +59,14 @@ class Events(str, Enum):
     NODE_SAVE_REQUESTED = "graph.node_save"
     REL_TYPES_REQUESTED = "graph.rel_types_requested"
     REL_TYPES_RECEIVED = "graph.rel_types_received"
+    REL_TYPE_DETAILS_REQUESTED = "graph.rel_type_details_requested"
+    REL_TYPE_DETAILS_RETURN = "graph.rel_types_details_return"
+
     REL_CREATE_REQUESTED = "graph.rel_create"
+    REL_UPDATE_REQUESTED = "graph.rel_update"
     REL_DELETE_REQUESTED = "graph.rel_delete"
     REL_DETAILS_REQUESTED = "graph.rel_details_requested"
-    REL_DETAILS_RETURN = "graph._rel_details_returned"
+    REL_DETAILS_RETURN = "graph._rel_details_return"
     
     # Export Events
     EXPORT_REQUESTED = "export.requested"


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [X] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

The RelationshipEditor now uses the Event Bus over the signals.
The signals still exist to connect the Nodes and Edges to functions
in RelationshipEditor but Any outside information now uses
the event bus for requesting and receiving information.

AppCoordinator was updated with new functions that
respond to requested information in RelationshipEditor.

Redundant Signals in AppCoordinator, RelationshipEditor,
MainWindow, and ViewManager have been removed.
These signals are no longer needed as the Event Bus now
handles all of this logic.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [X] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `nf_core_wrapper.py` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.