### PR TITLE
Fix Bug Where Outline failed to update visibility icon

### DIFF
--- a/src/python/ui/views/relationship_editor.py
+++ b/src/python/ui/views/relationship_editor.py
@@ -462,8 +462,7 @@ class RelationshipEditor(QWidget):
             node_item = self.nodes[node_id]
             node_item.setVisible(is_visible)
             
-            # Note: You may also want to hide connected edges 
-            # when a node is hidden, otherwise they will point to empty space.
+            # Make Connected Edges Invisible
             for edge in self.edges:
                 if edge.source_node == node_item or edge.target_node == node_item:
                     edge.setVisible(is_visible)

--- a/src/python/ui/views/relationship_outline_manager.py
+++ b/src/python/ui/views/relationship_outline_manager.py
@@ -268,6 +268,37 @@ class RelationshipOutlineManager(QWidget):
             'ID': char_id, 'is_hidden': not new_state
         })
 
+    @receiver(Events.GRAPH_NODE_VISIBILTY_CHANGED)
+    def sync_node_visibility_ui(self, data: dict) -> None:
+        """
+        Updates the character list icon when visibility is toggled from the graph.
+
+        :param data: dict: Data dict carrying {'ID': int, 'is_hidden': bool}
+        :type: data: dict:
+
+        :rtype:None
+        """
+        char_id = data.get('ID')
+        is_hidden = data.get('is_hidden')
+        is_visible = not is_hidden
+
+        # Find the item in the char_list_widget
+        for i in range(self.char_list_widget.count()):
+            item = self.char_list_widget.item(i)
+
+            if item.data(Qt.ItemDataRole.UserRole + 1) == char_id:
+                # Update the stored data state
+                item.setData(Qt.ItemDataRole.UserRole + 2, is_visible)
+                
+                # Update the widget icon
+                row_widget = self.char_list_widget.itemWidget(item)
+                if row_widget:
+                    # Assuming the toggle button is the last widget added to the layout
+                    toggle_btn = row_widget.layout().itemAt(row_widget.layout().count() - 1).widget()
+                    icon_path = ":icons/visible-on.svg" if is_visible else ":icons/visible-off.svg"
+                    toggle_btn.setIcon(QIcon(icon_path))
+                break
+
     def _show_context_menu(self, position: QPoint) -> None:
         """
         Shows the context menu for the list widget at the right-click position.

--- a/src/python/ui/widgets/graph_items.py
+++ b/src/python/ui/widgets/graph_items.py
@@ -266,8 +266,19 @@ class RelationshipEdge(QGraphicsLineItem):
         
         :rtype: None
         """
-        color = QColor(self.edge_data['color'])
-        thickness = max(1, self.edge_data['intensity']) # Value between 1-10
+        intensity = self.edge_data.get('intensity', 5) # Value between 1-10
+
+        color = QColor(self.edge_data.get('color', '#f0f0f0'))
+        intensity = self.edge_data.get('intensity', 5)
+
+        # Intensity-based opacity (50% to 100%)
+        opacity = 0.5 + (intensity / 10.0) * 0.5  # Maps 1-10 to 0.5-1.0
+        color.setAlphaF(opacity)
+        
+        # Power-scaled thickness
+        normalized = intensity / 10.0
+        thickness = 1 + (normalized ** 1.5) * 9
+        
         pen = QPen(color, thickness)
 
         # Line Style (Apply Solid, Dash, or Dot based on Data)


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [X] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

The Last PR #70 Introduced a bug where the visibility Icon
failed to update to the correct visibility on/off icon when
visibility was changed using the context menu on the node
in the graph layout.

esolved by registering RelationshipOutlineManager as a listener 
for GRAPH_NODE_VISIBILITY_CHANGED. After listening to the 
event it now correctly updates to the correcton/off visibility icon.

## 🔗 Related Tasks

- Fixes N/A

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [ ] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `nf_core_wrapper.py` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.