### PR TITLE
Updating the cursor in Rel Graph

### DIFF
--- a/src/python/ui/views/relationship_editor.py
+++ b/src/python/ui/views/relationship_editor.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QFrame, QDialog, QToolBar
 )
 from PySide6.QtCore import Qt, QLineF
-from PySide6.QtGui import QPen, QAction, QIcon
+from PySide6.QtGui import QPen, QAction, QIcon, QCursor
 from typing import Any
 
 from ...resources_rc import *

--- a/src/python/ui/views/relationship_outline_manager.py
+++ b/src/python/ui/views/relationship_outline_manager.py
@@ -107,8 +107,7 @@ class RelationshipOutlineManager(QWidget):
         Each item is set with the name as text and its ID and color in the data roles.
 
         :param data: A dictionary of the needed data containg {entity_type: EntityType.RELATIONSHIP,
-            'relationship_types': dict or 'characters': dict
-        }
+            'relationship_types': dict or 'characters': dict}
         :type data: dict
         
         :rtype: None

--- a/src/python/ui/widgets/graph_items.py
+++ b/src/python/ui/widgets/graph_items.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import (
     QGraphicsEllipseItem, QGraphicsLineItem, QGraphicsTextItem, QMenu
 )
 from PySide6.QtCore import Qt, QPointF, Signal, QRectF, QObject, QLineF, QEvent
-from PySide6.QtGui import QColor, QPen, QBrush, QFont, QMouseEvent
+from PySide6.QtGui import QColor, QPen, QBrush, QFont, QMouseEvent, QCursor
 import math
 from typing import Any, TYPE_CHECKING
 
@@ -76,6 +76,8 @@ class CharacterNode(QGraphicsEllipseItem):
         # set up dragging
         self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemIsMovable, True)
         self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
+        
+        self.setAcceptHoverEvents(True)
 
         # Add a name label
         self.label = QGraphicsTextItem(name, self)
@@ -100,6 +102,30 @@ class CharacterNode(QGraphicsEllipseItem):
         
         self.setBrush(brush)
         self.setPen(pen)
+
+    def hoverEnterEvent(self, event) -> None:
+        """
+        Changes cursor to drag cursor when hovering over the node.
+        
+        :param event: The hover event.
+        :type event: :py:class:`~PyQt6.QtWidgets.QGraphicsSceneHoverEvent`
+        
+        :rtype: None
+        """
+        self.setCursor(QCursor(Qt.CursorShape.SizeAllCursor))
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:
+        """
+        Restores default cursor when leaving the node.
+        
+        :param event: The hover event.
+        :type event: :py:class:`~PyQt6.QtWidgets.QGraphicsSceneHoverEvent`
+        
+        :rtype: None
+        """
+        self.unsetCursor()
+        super().hoverLeaveEvent(event)
 
     def itemChange(self, change: QGraphicsEllipseItem.GraphicsItemChange, value: Any) -> Any:
         """

--- a/src/python/ui/widgets/relationship_canvas.py
+++ b/src/python/ui/widgets/relationship_canvas.py
@@ -1,8 +1,8 @@
 # src/python/ui/widgets/relationship_canvas.py
 
 from PySide6.QtWidgets import QGraphicsView
-from PySide6.QtCore import QLineF, QRectF
-from PySide6.QtGui import QWheelEvent, QPainter, QMouseEvent, QPen, QColor
+from PySide6.QtCore import QLineF, QRectF, Qt
+from PySide6.QtGui import QWheelEvent, QPainter, QMouseEvent, QPen, QColor, QCursor
 
 class RelationshipCanvas(QGraphicsView):
     """
@@ -24,6 +24,8 @@ class RelationshipCanvas(QGraphicsView):
         self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
         self.setTransformationAnchor(QGraphicsView.ViewportAnchor.AnchorUnderMouse)
         self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.MinimalViewportUpdate)
+
+        self.viewport().setCursor(QCursor(Qt.CursorShape.ArrowCursor))
 
         # Grid Settings
         self.grid_size = 20
@@ -63,6 +65,8 @@ class RelationshipCanvas(QGraphicsView):
         
         :param enabled: True to enable the grid otherwise False.
         :type enabled: bool
+
+        :rtype: None
         """
         self.show_grid = enabled
         self.viewport().update()
@@ -99,10 +103,12 @@ class RelationshipCanvas(QGraphicsView):
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         """
-        Docstring for mouseMoveEvent
+        Handles what the moust moves and a Node A is selected.
         
-        :param self: Description
-        :param event: Description
+        :param event: The Mouse event.
+        :type event: QMouseEvent
+
+        :rtype: None
         """
         editor = self.parent()
         if hasattr(editor, 'temp_line') and editor.temp_line and editor.selected_node_a:


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

The Default Cursor in the RelationshipEditor is now just
the arrow cursor. The Cursor changes when hovering over
a node to indicate to the user that they can move the node.
The cursor changes back when unhovering the node.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `nf_core_wrapper.py` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.