### PR TITLE
Added Spell Checking Setting

### DIFF
--- a/config/default_settings.json
+++ b/config/default_settings.json
@@ -1,5 +1,5 @@
 {
-    "debug_mode": true,
+    "debug_mode": false,
     "last_project_path": "",
     "theme": "Blue",
     "window_size": "1200x800",
@@ -8,5 +8,6 @@
     "window_height": 800,
     "window_pos_x": 100,
     "window_pos_y": 100,
-    "words_per_minute": 250
+    "words_per_minute": 250,
+    "is_spell_checking": false
 }

--- a/src/python/main_window.py
+++ b/src/python/main_window.py
@@ -375,7 +375,7 @@ class MainWindow(QMainWindow):
             logger.debug(f"WPM setting changed: {old_wpm} -> {new_wpm}. Updating ChapterEditor.")
             self.view_manager.set_wpm(new_wpm)
 
-        # CRITICAL: Update the main window's internal state to the new settings dictionary
+        # Update the main window's internal state to the new settings dictionary
         self.current_settings = new_settings
 
         # 2. Apply Theme

--- a/src/python/services/settings_manager.py
+++ b/src/python/services/settings_manager.py
@@ -65,7 +65,8 @@ class SettingsManager:
                     "window_width": 1200,
                     "window_height": 800,
                     "window_pos_x": 100,
-                    "window_pos_y": 100
+                    "window_pos_y": 100,
+                    "is_spell_checking": False
                 }
 
                 with open(self._DEFAULT_FILE,'w') as f:
@@ -99,9 +100,6 @@ class SettingsManager:
         merged_settings.update(user_settings)
         
         logger.info(f"Settings loaded and merged successfully. Keys: {len(merged_settings)}.")
-        
-        # CRITICAL FIX: The save_settings call is absent here.
-        # This prevents the repetitive loading/saving loop.
         
         return merged_settings
     

--- a/src/python/ui/dialogs/settings_dialog.py
+++ b/src/python/ui/dialogs/settings_dialog.py
@@ -3,7 +3,7 @@
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QGroupBox, QComboBox, 
     QLabel, QDialogButtonBox, QHBoxLayout, QPushButton,
-    QMessageBox, QSpinBox
+    QMessageBox, QSpinBox, QCheckBox
 )
 from typing import Any
 
@@ -41,6 +41,7 @@ class SettingsDialog(QDialog):
         self.setGeometry(200, 200, 600, 400)
 
         self.settings_manager = settings_manager
+        self.current_settings = current_settings
         self._new_settings = current_settings.copy()
 
         self._setup_ui()
@@ -122,6 +123,17 @@ class SettingsDialog(QDialog):
         wpm_layout.addStretch()
         stats_layout.addLayout(wpm_layout)
 
+        # Is Spell Checking Setting
+        spell_layout = QHBoxLayout()
+        spell_label = QLabel("Toggle on/off Spell Checking:")
+        self.spell_box = QCheckBox()
+        self.spell_box.setChecked(self.current_settings.get('is_spell_checking', False))
+
+        spell_layout.addWidget(spell_label)
+        spell_layout.addWidget(self.spell_box)
+        spell_layout.addStretch()
+        stats_layout.addLayout(spell_layout)
+
         # --- Appearance Group Box (Themes) ---
         appearance_group = QGroupBox("Appearance")
         themes_layout = QVBoxLayout(appearance_group)
@@ -187,8 +199,11 @@ class SettingsDialog(QDialog):
         self._new_settings['outline_width_pixels'] = self.outline_width_spinbox.value()
         new_wpm = self.wpm_spinBox.value()
         self._new_settings['words_per_minute'] = new_wpm
+        new_is_spell_checking = self.spell_box.isChecked()
+        self._new_settings['is_spell_checking'] = new_is_spell_checking
 
         bus.publish(Events.WPM_CHANGED, data={'new_wpm': new_wpm})
+        bus.publish(Events.IS_SPELL_CHECKING_CHANGED, data={'is_spell_checking': new_is_spell_checking})
         
         self.accept()
 

--- a/src/python/ui/ui_factory.py
+++ b/src/python/ui/ui_factory.py
@@ -36,10 +36,10 @@ class UIFactory:
             'chapter_editor': ChapterEditor(settings),
             
             'lore_outline': LoreOutlineManager(project_title=project_title),
-            'lore_editor': LoreEditor(),
+            'lore_editor': LoreEditor(settings),
             
             'character_outline': CharacterOutlineManager(project_title=project_title),
-            'character_editor': CharacterEditor(),
+            'character_editor': CharacterEditor(settings),
             
             'note_outline': NoteOutlineManager(project_title=project_title),
             'note_editor': NoteEditor(settings),

--- a/src/python/ui/views/chapter_editor.py
+++ b/src/python/ui/views/chapter_editor.py
@@ -54,7 +54,7 @@ class ChapterEditor(BaseEditor):
         self.current_lookup_dialog = None
 
         # --- Sub-components ---
-        self.text_editor = RichTextEditor()
+        self.text_editor = RichTextEditor(self.current_settings)
         
         # --- Statistics Labels ---
         self.word_count_label = QLabel("Words: 0")

--- a/src/python/ui/views/character_editor.py
+++ b/src/python/ui/views/character_editor.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QGroupBox, 
     QLineEdit, QComboBox, QHBoxLayout, QSpinBox
 )
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt
 from typing import Any
 
 from .base_editor import BaseEditor
@@ -35,10 +35,12 @@ class CharacterEditor(BaseEditor):
     current_char_id: int | None = None
     """The database ID of the character currently loaded in the editor, or :py:obj:`None`."""
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, current_settings: dict, parent=None) -> None:
         """
         Initializes the :py:class:`.CharacterEditor` widget.
         
+        :param current_settings: A dictionary containing initial application settings.
+        :type current_settings: dict
         :param parent: The parent widget. Defaults to ``None``.
         :type parent: :py:class:`~PySide6.QtWidgets.QWidget`, optional
 
@@ -50,9 +52,11 @@ class CharacterEditor(BaseEditor):
 
         self._dirty = False
 
+        is_spell_checking = current_settings.get('is_spell_checking')
+
         # --- 1. Sub-components ---
-        self.description_editor = BasicTextEditor()
-        self.text_editor = BasicTextEditor()  # Moved up for clarity
+        self.description_editor = BasicTextEditor(is_spell_checking)
+        self.text_editor = BasicTextEditor(is_spell_checking)  # Moved up for clarity
         self.name_input = QLineEdit()
         self.name_input.setPlaceholderText("Enter Character Name")
         

--- a/src/python/ui/views/lore_editor.py
+++ b/src/python/ui/views/lore_editor.py
@@ -27,10 +27,12 @@ class LoreEditor(BaseEditor):
     current_lore_id: int | None = None
     """The database ID of the Lore Entry currently loaded in the editor, or :py:obj:`None`."""
     
-    def __init__(self, parent=None) -> None:
+    def __init__(self, current_settings: dict, parent=None) -> None:
         """
         Initializes the :py:class:`.LoreEditor` widget.
         
+        :param current_settings: A dictionary containing initial application settings.
+        :type current_settings: dict
         :param parent: The parent widget.
         :type parent: :py:class:`~PySide6.QtWidgets.QWidget`, optional
 
@@ -41,9 +43,11 @@ class LoreEditor(BaseEditor):
         bus.register_instance(self)
 
         self._dirty = False
+
+        is_spell_checking = current_settings.get('is_spell_checking')
         
         # --- Sub-components ---
-        self.text_editor = BasicTextEditor()
+        self.text_editor = BasicTextEditor(is_spell_checking)
 
         # --- Lore-Specific Components (Title and Category) ---
         self.title_input = QLineEdit()

--- a/src/python/ui/views/note_editor.py
+++ b/src/python/ui/views/note_editor.py
@@ -42,7 +42,7 @@ class NoteEditor(BaseEditor):
         self.current_lookup_dialog = None
 
         # --- Sub-components ---
-        self.text_editor = RichTextEditor()
+        self.text_editor = RichTextEditor(current_settings)
 
         # --- Layout ---
         main_layout = QVBoxLayout(self)

--- a/src/python/ui/widgets/rich_text_editor.py
+++ b/src/python/ui/widgets/rich_text_editor.py
@@ -37,16 +37,18 @@ class RichTextEditor(BasicTextEditor):
     :vartype editor: :py:class:`PySide6.QtWidgets.QTextEdit`
     """
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, current_settings: dict={}, parent=None) -> None:
         """
         Initializes the RichTextEditor and connects its signals
 
+        :param current_settings: A dictionary containing initial application settings.
+        :type current_settings: dict
         :param parent: The parent widget. Defaults to ``None``.
         :type parent: :py:class:`PySide6.QtWidgets.QWidget`
 
         :rtype: None
         """
-        super().__init__(parent)
+        super().__init__(is_spell_checking=current_settings.get('is_spell_checking', False), parent=parent)
 
         logger.debug("Initializing RichTextEditor (including its toolbar).")
 

--- a/src/python/utils/events.py
+++ b/src/python/utils/events.py
@@ -97,6 +97,7 @@ class Events(str, Enum):
     SETTINGS_REQUESTED = "settings.requested"
     SETTINGS_CHANGED = "settings.changed"
     WPM_CHANGED = "settings.wpm_changed"
+    IS_SPELL_CHECKING_CHANGED = "settings.is_spell_checking_changed"
     
     # Project Events
     PROJECT_NEW_REQUESTED = "project.new_requested"


### PR DESCRIPTION
A New Setting that allows the user to toggle on/off the spell checker.

This is a global setting so it will affect every Text Editor.

## 🏷️ PR Type

- [X] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

A New Setting that toggles on/off the Spell Checker in the
Basic Text Editor and its child Rich Text Editor. This is a global
setting affecting all of them.

UIFactory was updated so settings is passed to all
Editors and these Editor passes it into RichTextEditor
or BasicTextEditor. This is how BasicTextEditor knows
the previous applied settings.

The Settings Dialog Window was update to
display the new setting as a Check Box.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.