### PR TITLE
Fix Bug where Lore Title did not update Outline

### DIFF
--- a/src/python/ui/views/lore_editor.py
+++ b/src/python/ui/views/lore_editor.py
@@ -255,10 +255,9 @@ class LoreEditor(BaseEditor):
         """
         if self.current_lore_id is not None:
             bus.publish(Events.OUTLINE_NAME_CHANGE, data={
-                'editor': self,
+                'entity_type': EntityType.LORE,
                 'ID': self.current_lore_id,
-                'title': self.title_input.text().strip(),
-                'view': ViewType.LORE_EDITOR
+                'new_title': self.title_input.text().strip(),
             })
 
     def get_save_data(self) -> dict:


### PR DESCRIPTION
When using the Text Bar at the top of
the Lore Editor it failed to update the
name in Outline.

This has been fixed by accurately
publishing the correct data when
emitting the OUTLINE_NAME_CHANGE
event in Lore Editor.

## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

When using the Text Bar at the top of
the Lore Editor it failed to update the
name in Outline.

This has been fixed by accurately
publishing the correct data when
emitting the OUTLINE_NAME_CHANGE
event in Lore Editor.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.