### PR TITLE
Fix Bug now showing Full Text Size

### DIFF
--- a/src/python/ui/widgets/rich_text_editor.py
+++ b/src/python/ui/widgets/rich_text_editor.py
@@ -113,7 +113,7 @@ class RichTextEditor(BasicTextEditor):
             # Font Size Selector
             self.size_combo = QComboBox(self.toolbar)
             self.size_combo.setEditable(True)
-            self.size_combo.setFixedWidth(50)
+            self.size_combo.setFixedWidth(60)
             # Standard sizes for rich text editors
             self.size_combo.addItems([
                 "8", "9", "10", "11", "12", "14", "16", "18", "20", "22", "24", "26", "28", "36", "48", "72"


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [X] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

The Text Size was clipped not showing
the full 2 digit number in the Rich
Text Editor.

This has been fixed by making the
fixed width size to be 60 instead of
50.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.