### PR TITLE
Fix Lookup Event Firing Empty Text

### DIFF
--- a/src/python/services/app_coordinator.py
+++ b/src/python/services/app_coordinator.py
@@ -862,6 +862,7 @@ class AppCoordinator(QObject):
         """
 
         name = data.get('selected_text', '').strip()
+        print(name)
         if not name: return
 
         # Start Searching For Characters

--- a/src/python/ui/widgets/basic_text_editor.py
+++ b/src/python/ui/widgets/basic_text_editor.py
@@ -270,6 +270,8 @@ class BasicTextEditor(QWidget):
         """
         selected_text = self.get_selected_text().strip()
 
+        if not selected_text: return
+
         bus.publish(Events.PERFORM_DATABASE_LOOKUP, data={'selected_text': selected_text})
 
     @receiver(Events.IS_SPELL_CHECKING_CHANGED)


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [X] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

This adds a check in BasicTextEditor to make sure this is
selected Text before firing the Lookup Requested Event.

This ensures that only the BasicTextEditor that has selected Text
is the one firing the event eliminating duplicate event calling.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [ ] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change (`schema_v1.sql`)
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.