### PR TITLE
Pressing Esc clears Node Selection

### DIFF
--- a/src/python/ui/views/relationship_editor.py
+++ b/src/python/ui/views/relationship_editor.py
@@ -4,8 +4,8 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QGraphicsView, QGraphicsScene, QGraphicsLineItem, QMessageBox, 
     QFrame, QDialog, QToolBar, QSlider, QLabel, QHBoxLayout
 )
-from PySide6.QtCore import Qt, QLineF, QPointF
-from PySide6.QtGui import QPen, QAction, QIcon
+from PySide6.QtCore import Qt, QLineF, QPointF, QEvent
+from PySide6.QtGui import QPen, QAction, QIcon, QKeyEvent
 from typing import Any
 import math
 
@@ -765,3 +765,15 @@ class RelationshipEditor(QWidget):
         :rtype: None
         """
         pass
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """
+        Docstring for keyPressEvent
+        
+        :param self: Description
+        :param event: Description
+        :type event: QKeyEvent
+        """
+        if event.key() == Qt.Key.Key_Escape:
+            if self.selected_node_a:
+                self.clear_selection()


### PR DESCRIPTION
## 🏷️ PR Type

- [X] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

When pressing the Esc key in the
Relationship Editor now clears
the selection. Much easier to back out
if inadvertently pressing the connect.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.