### PR TITLE
Note Editor now has Title Editing

### DIFF
--- a/src/python/repository/note_repository.py
+++ b/src/python/repository/note_repository.py
@@ -51,9 +51,9 @@ class NoteRepository:
             logger.error("Failed to retrieve all basic notes.", exc_info=True)
             raise e
         
-    def get_note_content(self, note_id: int) -> str | None:
+    def get_note_details(self, note_id: int) -> str | None:
         """
-        Retrieves the content for a specific note ID
+        Retrieves the title and content for a specific note ID.
         
         Gathers only the content of a note.
 
@@ -63,12 +63,11 @@ class NoteRepository:
         :returns: Returns a str of the content if successful, otherwise None
         :rtype: str or None
         """
-        query = "SELECT Content FROM Notes WHERE ID = ?;"
+        query = "SELECT Title, Content FROM Notes WHERE ID = ?;"
         try:
             result = self.db._execute_query(query, (note_id,), fetch_one=True)
-            content = result['Content'] if result else None
-            logger.debug(f"Retrieved content for Note ID: {note_id}. Found: {content is not None}")
-            return content
+            logger.debug(f"Retrieved content for Note ID: {note_id}.")
+            return result
         except DatabaseError as e:
             logger.error(f"Failed to retrieve content for Note ID: {note_id}.", exc_info=True)
             raise e

--- a/src/python/services/app_coordinator.py
+++ b/src/python/services/app_coordinator.py
@@ -438,11 +438,12 @@ class AppCoordinator(QObject):
             return_data |= self.character_repo.get_character_details(char_id=item_id)
 
         elif entity_type == EntityType.NOTE:
-            content = self.note_repo.get_note_content(note_id=item_id)
+            note_data: dict = self.note_repo.get_note_details(note_id=item_id)
             tags_data = self.tag_repo.get_tags_for_note(item_id)
             tag_names = [name for _, name in tags_data] if tags_data else []
             return_data['ID'] = item_id
-            return_data['content'] = content
+            return_data['title'] = note_data.get('Title')
+            return_data['content'] = note_data.get('Content', '')
             return_data['tags'] = tag_names
 
         bus.publish(Events.DATA_LOADED, data=return_data)

--- a/src/python/ui/views/chapter_editor.py
+++ b/src/python/ui/views/chapter_editor.py
@@ -32,7 +32,7 @@ class ChapterEditor(BaseEditor):
     """
 
     current_chapter_id: int | None = None
-    """The database ID of the Lore Entry currently loaded in the editor, or :py:obj:`None`."""
+    """The database ID of the Chapter currently loaded in the editor, int or None."""
     
     def __init__(self, current_settings: dict, parent=None) -> None:
         """
@@ -301,21 +301,6 @@ class ChapterEditor(BaseEditor):
             return False
         
         self._dirty = True
-
-    @receiver(Events.MARK_SAVED)
-    def mark_saved_connection(self, data: dict) -> None:
-        """
-        A connection for the mark saved Event.
-        
-        :param data: Data dictionary, Empty as function doesn't need it.
-        :type data: dict
-
-        :rtype: None
-        """
-        if data.get('entity_type') != EntityType.CHAPTER:
-            return
-        
-        self.mark_saved()
 
     def mark_saved(self) -> None:
         """

--- a/src/python/ui/views/note_editor.py
+++ b/src/python/ui/views/note_editor.py
@@ -1,6 +1,8 @@
 # src/python/ui/note_editor.py
 
-from PySide6.QtWidgets import QVBoxLayout, QGroupBox, QSplitter
+from PySide6.QtWidgets import (
+    QVBoxLayout, QGroupBox, QSplitter, QLineEdit, QWidget, QHBoxLayout, QLabel
+)
 from PySide6.QtCore import Qt
 
 from .base_editor import BaseEditor
@@ -24,6 +26,9 @@ class NoteEditor(BaseEditor):
     :ivar tag_manager: The tag management component.
     :vartype tag_manager: TagManagerWidget
     """
+
+    current_note_id: int | None = None
+    """The database ID of the Note currently loaded in the editor, int or None."""
     
     def __init__(self, current_settings, parent=None) -> None:
         """
@@ -49,22 +54,36 @@ class NoteEditor(BaseEditor):
         main_layout.setContentsMargins(10, 10, 10, 10)
         main_layout.setSpacing(10)
 
-        # 1. Tagging Group Box
+        # Title group
+        title_group = QWidget()
+        title_layout = QHBoxLayout(title_group)
+        self.title_input = QLineEdit()
+        self.title_input.setPlaceholderText("Enter Note Title (e.g., 'Outline, Story Idea)")
+        title_label = QLabel("Title:")
+        
+        title_layout.addWidget(title_label)
+        title_layout.addWidget(self.title_input)
+
+        # Tagging Group Box
         tag_group = QGroupBox("Note Tags (Genres, Themes, POVs)")
         tag_group.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tag_layout = QVBoxLayout(tag_group)
         tag_layout.setContentsMargins(10, 20, 10, 10)
         tag_layout.addWidget(self.tag_manager)
 
+        # Splitter
         editor_splitter = QSplitter(Qt.Orientation.Vertical)
-        editor_splitter.addWidget(tag_group) # Use the new group containing stats bar
+        editor_splitter.addWidget(title_group)
+        editor_splitter.addWidget(tag_group)
         editor_splitter.addWidget(self.text_editor)
-        editor_splitter.setSizes([100, 900]) 
+        editor_splitter.setSizes([100, 100, 800]) 
 
-        # Add the splitter to the main layout
         main_layout.addWidget(editor_splitter)
 
         self.setEnabled(False)
+
+        self.title_input.textChanged.connect(self._set_dirty)
+        self.title_input.editingFinished.connect(self._emit_title_change)
 
     @receiver(Events.MARK_SAVED)
     def mark_saved_connection(self, data: dict) -> None:
@@ -111,6 +130,8 @@ class NoteEditor(BaseEditor):
         :rtype: dict
         """
         return {
+            'ID': self.current_note_id,
+            'title': self.title_input.text(),
             'content': self.text_editor.get_html_content(),
             'tags': self.tag_manager.get_tags()
         }
@@ -149,11 +170,61 @@ class NoteEditor(BaseEditor):
         """
         if data.get('entity_type') != EntityType.NOTE:
             return
+        
+        self.current_note_id = data.get('ID')
+        if not self.current_note_id:
+            return
 
-        content, tags = data['content'], data['tags']
-
-        self.text_editor.set_html_content(content)
-        self.tag_manager.set_tags(tags)
+        self.title_input.setText((data.get('title')))
+        self.tag_manager.set_tags(data.get('tags'))
+        self.text_editor.set_html_content(data.get('content'))
 
         self.mark_saved()
         self.set_enabled(True)
+
+    def is_dirty(self) -> bool:
+        """
+        Returns the dirty flag to see if the editor is dirty.
+        
+        :returns: True if changes are detected, False otherwise.
+        :rtype: bool
+        """
+        return self._dirty or super().is_dirty()
+    
+    def _set_dirty(self) -> None:
+        """
+        Sets the dirty flag to be True.
+        
+        :rtype: None
+        """
+        if not self.current_note_id:
+            return False
+        
+        self._dirty = True
+
+    def set_enabled(self, enabled: bool) -> None:
+        """
+        Enables/disables the entire editor panel.
+        
+        :param enabled: True if want to enable editor panel, otherwise False
+        :type enabled: bool
+        
+        :rtype: None
+        """
+        # self.text_editor and self.tag_manager
+        super().set_enabled(enabled)
+
+        self.title_input.setEnabled(enabled)
+
+    def _emit_title_change(self) -> None:
+        """
+        Emits the signal to update the outline after the user finishes editing the title.
+        
+        :rtype: None
+        """
+        if self.current_note_id is not None:
+            bus.publish(Events.OUTLINE_NAME_CHANGE, data={
+                'entity_type': EntityType.NOTE,
+                'ID': self.current_note_id,
+                'new_title': self.title_input.text().strip(),
+            })


### PR DESCRIPTION
## 🏷️ PR Type

- [X] **feat**: A new feature (e.g., adding the Notes feature)
- [ ] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

You can now edit the title of the note
directly in the Note Editor. This makes it
much easier to edit the note title for
the user.

This required Editing the AppCoordinator
and NoteRepository in order to ensure
the correct data is being sent across.

This mainly edits the NoteEditor to
show the new Widget.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [X] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.