### PR TITLE
Fix Bug with Title Change

### DIFF
--- a/src/python/ui/views/chapter_editor.py
+++ b/src/python/ui/views/chapter_editor.py
@@ -116,7 +116,6 @@ class ChapterEditor(BaseEditor):
         self.setEnabled(False)
 
         self.title_input.textChanged.connect(self._set_dirty)
-        self.title_input.editingFinished.connect(self._emit_title_change)
 
     @receiver(Events.CONTENT_CHANGED)
     @receiver(Events.SELECTION_CHANGED)
@@ -327,16 +326,3 @@ class ChapterEditor(BaseEditor):
         super().set_enabled(enabled)
 
         self.title_input.setEnabled(enabled)
-
-    def _emit_title_change(self) -> None:
-        """
-        Emits the signal to update the outline after the user finishes editing the title.
-        
-        :rtype: None
-        """
-        if self.current_chapter_id is not None:
-            bus.publish(Events.OUTLINE_NAME_CHANGE, data={
-                'entity_type': EntityType.CHAPTER,
-                'ID': self.current_chapter_id,
-                'new_title': self.title_input.text().strip(),
-            })

--- a/src/python/ui/views/character_editor.py
+++ b/src/python/ui/views/character_editor.py
@@ -121,7 +121,7 @@ class CharacterEditor(BaseEditor):
         self.dob_input.textChanged.connect(self._set_dirty)
         self.occupation_input.textChanged.connect(self._set_dirty)
         
-        self.name_input.editingFinished.connect(self._emit_name_change)
+        self.name_input.textChanged.connect(self._set_dirty)
         
         self.setEnabled(False)
     
@@ -203,20 +203,6 @@ class CharacterEditor(BaseEditor):
         self.dob_input.setEnabled(enabled)
         self.occupation_input.setEnabled(enabled)
         self.description_editor.setEnabled(enabled)
-
-    def _emit_name_change(self) -> None:
-        """
-        Emits the :py:attr:`.char_name_changed` signal after the user finishes 
-        editing the name (e.g., focus leaves the :py:class:`~PySide6.QtWidgets.QLineEdit`).
-        
-        :rtype: None
-        """
-        if self.current_char_id is not None:
-            bus.publish(Events.OUTLINE_NAME_CHANGE, data={
-                'entity_type': EntityType.CHARACTER,
-                'ID': self.current_char_id,
-                'new_title': self.name_input.text().strip(),
-            })
 
     def get_save_data(self) -> dict:
         """

--- a/src/python/ui/views/lore_editor.py
+++ b/src/python/ui/views/lore_editor.py
@@ -101,9 +101,6 @@ class LoreEditor(BaseEditor):
         self.title_input.textChanged.connect(self._set_dirty)
         self.category_combo.currentIndexChanged.connect(self._set_dirty)
         
-        # Emit signal when title edit is finished (for Outline update)
-        self.title_input.editingFinished.connect(self._emit_title_change)
-        
         self.set_enabled(False)
         self.mark_saved()
 
@@ -188,19 +185,6 @@ class LoreEditor(BaseEditor):
 
         self.title_input.setEnabled(enabled)
         self.category_combo.setEnabled(enabled)
-
-    def _emit_title_change(self) -> None:
-        """
-        Emits the signal to update the outline after the user finishes editing the title.
-        
-        :rtype: None
-        """
-        if self.current_lore_id is not None:
-            bus.publish(Events.OUTLINE_NAME_CHANGE, data={
-                'entity_type': EntityType.LORE,
-                'ID': self.current_lore_id,
-                'new_title': self.title_input.text().strip(),
-            })
 
     def get_save_data(self) -> dict:
         """

--- a/src/python/ui/views/note_editor.py
+++ b/src/python/ui/views/note_editor.py
@@ -83,7 +83,6 @@ class NoteEditor(BaseEditor):
         self.setEnabled(False)
 
         self.title_input.textChanged.connect(self._set_dirty)
-        self.title_input.editingFinished.connect(self._emit_title_change)
 
     @receiver(Events.MARK_SAVED)
     def mark_saved_connection(self, data: dict) -> None:
@@ -215,16 +214,3 @@ class NoteEditor(BaseEditor):
         super().set_enabled(enabled)
 
         self.title_input.setEnabled(enabled)
-
-    def _emit_title_change(self) -> None:
-        """
-        Emits the signal to update the outline after the user finishes editing the title.
-        
-        :rtype: None
-        """
-        if self.current_note_id is not None:
-            bus.publish(Events.OUTLINE_NAME_CHANGE, data={
-                'entity_type': EntityType.NOTE,
-                'ID': self.current_note_id,
-                'new_title': self.title_input.text().strip(),
-            })


### PR DESCRIPTION
## 🏷️ PR Type

- [ ] **feat**: A new feature (e.g., adding the Notes feature)
- [X] **fix**: A bug fix (e.g., edge update lag)
- [ ] **refactor**: Moving to QFrame or improving UI consistency
- [ ] **perf**: C++ core optimizations or C-API improvements
- [ ] **docs**: Documentation updates (README, SCHEMA, etc.)
- [ ] **chore**: Updating build tasks, dependencies, tools.

## 📝 Description

Fix Bug where the title would update
when the user would want to switch
to another entity before the user
was prompted to save their changes.

This has been fixed been removing the emit connection when editing is finished on the text box. So now pressing enter
will not save the chapter. The user has
to press the save button or Ctrl+S
to save their chapter changes or when
prompted if the entity is dirty and trying
to switch to a different entity.

## 🔗 Related Tasks

- Fixes #

### **Frontend (Python)**

- [ ] Modified `repository/` or `services/`
- [X] Updated `ui/` views or `widgets/`

### **Core (C++ & Bridge)**

- [ ] Modified `c_lib/` (e.g., `graph_layout_engine.cpp`)
- [ ] Updated `Python C++ Wrappers` or C-API `Node`/`Edge` structs

### **Data & Schema**

- [ ] Database Schema change
- [ ] Migration of project folder structure

## ✅ Quality Checklist'

- [X] **Unit Tests**: All tests in `tests/` pass with current changes.
- [X] **C++ Integrity**: No memory leaks or segmentation faults in the `nf_core_lib`.
- [X] **Python Wrapper**: Mandatory workflow followed (no raw `_clib` calls in UI).
- [X] **Styling**: UI changes are compatible with existing `.qss` theme files.